### PR TITLE
Clean up endian-conversion code

### DIFF
--- a/libwired/base/wi-byteorder.h
+++ b/libwired/base/wi-byteorder.h
@@ -44,127 +44,75 @@
 #include <sys/param.h>
 #include <inttypes.h>
 
-#if defined(BYTE_ORDER) && defined(BIG_ENDIAN) && defined(LITTLE_ENDIAN)
-#if BYTE_ORDER == BIG_ENDIAN
-#define WI_BIG_ENDIAN                       1
-#elif BYTE_ORDER == LITTLE_ENDIAN
-#define WI_LITTLE_ENDIAN                    1
-#else
-#error Unknown byte order
-#endif
-#elif defined(__BIG_ENDIAN__) || defined(_BIG_ENDIAN)
-#define WI_BIG_ENDIAN                       1
-#elif defined(__LITTLE_ENDIAN__) || defined(_LITTLE_ENDIAN)
-#define WI_LITTLE_ENDIAN                    1
-#else
-#error Unknown byte order
-#endif
-
-
-#define WI_SWAP_INT16(n)												\
-    ((uint16_t) ((((uint16_t) (n) & 0xFF00) >> 8) |						\
-				 (((uint16_t) (n) & 0x00FF) << 8)))
-
-#define WI_SWAP_INT32(n)												\
-    ((uint32_t) ((((uint32_t) (n) & 0xFF000000) >> 24) |				\
-				 (((uint32_t) (n) & 0x00FF0000) >>  8) |				\
-				 (((uint32_t) (n) & 0x0000FF00) <<  8) |				\
-				 (((uint32_t) (n) & 0x000000FF) << 24)))
-
-#define WI_SWAP_INT64(n)												\
-	((uint64_t) ((((uint64_t) (n) & 0xFF00000000000000ULL) >> 56) |		\
-				 (((uint64_t) (n) & 0x00FF000000000000ULL) >> 40) |		\
-				 (((uint64_t) (n) & 0x0000FF0000000000ULL) >> 24) |		\
-				 (((uint64_t) (n) & 0x000000FF00000000ULL) >>  8) |		\
-				 (((uint64_t) (n) & 0x00000000FF000000ULL) <<  8) |		\
-				 (((uint64_t) (n) & 0x0000000000FF0000ULL) << 24) |		\
-				 (((uint64_t) (n) & 0x000000000000FF00ULL) << 40) |		\
-				 (((uint64_t) (n) & 0x00000000000000FFULL) << 56)))
-
-
-#ifdef WI_BIG_ENDIAN
-
-#define WI_SWAP_HOST_TO_BIG_INT16(n)		(n)
-#define WI_SWAP_HOST_TO_BIG_INT32(n)		(n)
-#define WI_SWAP_HOST_TO_BIG_INT64(n)		(n)
-
-#define WI_SWAP_HOST_TO_LITTLE_INT16(n)		WI_SWAP_INT16(n)
-#define WI_SWAP_HOST_TO_LITTLE_INT32(n)		WI_SWAP_INT32(n) 
-#define WI_SWAP_HOST_TO_LITTLE_INT64(n)		WI_SWAP_INT64(n) 
-    
-#define WI_SWAP_BIG_TO_HOST_INT16(n)		(n)
-#define WI_SWAP_BIG_TO_HOST_INT32(n)		(n)
-#define WI_SWAP_BIG_TO_HOST_INT64(n)		(n)
-   
-#define WI_SWAP_LITTLE_TO_HOST_INT16(n)		WI_SWAP_INT16(n)
-#define WI_SWAP_LITTLE_TO_HOST_INT32(n)		WI_SWAP_INT32(n)
-#define WI_SWAP_LITTLE_TO_HOST_INT64(n)		WI_SWAP_INT64(n)
-
-#else
-
-#define WI_SWAP_HOST_TO_BIG_INT16(n)		WI_SWAP_INT16(n)
-#define WI_SWAP_HOST_TO_BIG_INT32(n)		WI_SWAP_INT32(n)
-#define WI_SWAP_HOST_TO_BIG_INT64(n)		WI_SWAP_INT64(n)
-
-#define WI_SWAP_HOST_TO_LITTLE_INT16(n)		(n)
-#define WI_SWAP_HOST_TO_LITTLE_INT32(n)		(n)
-#define WI_SWAP_HOST_TO_LITTLE_INT64(n)		(n) 
-
-#define WI_SWAP_BIG_TO_HOST_INT16(n)		WI_SWAP_INT16(n)
-#define WI_SWAP_BIG_TO_HOST_INT32(n)		WI_SWAP_INT32(n)
-#define WI_SWAP_BIG_TO_HOST_INT64(n)		WI_SWAP_INT64(n)
-
-#define WI_SWAP_LITTLE_TO_HOST_INT16(n)		(n)
-#define WI_SWAP_LITTLE_TO_HOST_INT32(n)		(n)
-#define WI_SWAP_LITTLE_TO_HOST_INT64(n)		(n)
-
-#endif
-
-
 static inline uint16_t wi_read_swap_big_to_host_int16(void *base, uintptr_t offset) {
-	uint16_t	n;
-
-	n = *(uint16_t *) ((uintptr_t) base + offset);
+	uint16_t	n = 0;
+	uint8_t	*p = base;
+	n |= p[offset + 0] << 8;
+	n |= p[offset + 1] << 0;
 	
-	return WI_SWAP_BIG_TO_HOST_INT16(n);
+	return n;
 }
 
 
 
 static inline uint32_t wi_read_swap_big_to_host_int32(void *base, uintptr_t offset) {
-	uint32_t	n;
+	uint32_t	n = 0;
+	uint8_t	*p = base;
+	n |= p[offset + 0] << 24;
+	n |= p[offset + 1] << 16;
+	n |= p[offset + 2] << 8;
+	n |= p[offset + 3] << 0;
 	
-	n = *(uint32_t *) ((uintptr_t) base + offset);
-	
-	return WI_SWAP_BIG_TO_HOST_INT32(n);
+	return n;
 }
 
 
 
 static inline uint64_t wi_read_swap_big_to_host_int64(void *base, uintptr_t offset) {
-	uint64_t		n;
-	
-	n = *(uint64_t *) ((uintptr_t) base + offset);
-	
-	return WI_SWAP_BIG_TO_HOST_INT64(n);
+	uint64_t	n = 0;
+	uint8_t	*p = base;
+	n |= (uint64_t)(p[offset + 0]) << 56;
+	n |= (uint64_t)(p[offset + 1]) << 48;
+	n |= (uint64_t)(p[offset + 2]) << 40;
+	n |= (uint64_t)(p[offset + 3]) << 32;
+	n |= (uint64_t)(p[offset + 4]) << 24;
+	n |= (uint64_t)(p[offset + 5]) << 16;
+	n |= (uint64_t)(p[offset + 6]) <<  8;
+	n |= (uint64_t)(p[offset + 7]) <<  0;
+
+	return n;
 }
 
 
 
 static inline void wi_write_swap_host_to_big_int16(void *base, uintptr_t offset, uint16_t n) {
-	*(uint16_t *) ((uintptr_t) base + offset) = WI_SWAP_HOST_TO_BIG_INT16(n);
+	uint8_t	*p = base;
+	p[offset + 0] = (0xFF00 & n) >> 8;
+	p[offset + 1] = (0x00FF & n) >> 0;
 }
 
 
 
 static inline void wi_write_swap_host_to_big_int32(void *base, uintptr_t offset, uint32_t n) {
-	*(uint32_t *) ((uintptr_t) base + offset) = WI_SWAP_HOST_TO_BIG_INT32(n);
+	uint8_t	*p = base;
+	p[offset + 0] = (0xFF000000 & n) >> 24;
+	p[offset + 1] = (0x00FF0000 & n) >> 16;
+	p[offset + 2] = (0x0000FF00 & n) >>  8;
+	p[offset + 3] = (0x000000FF & n) >>  0;
 }
 
 
 
 static inline void wi_write_swap_host_to_big_int64(void *base, uintptr_t offset, uint64_t n) {
-	*(uint64_t *) ((uintptr_t) base + offset) = WI_SWAP_HOST_TO_BIG_INT64(n);
+	uint8_t	*p = base;
+	p[offset + 0] = (n & 0xFF00000000000000ULL) >> 56;
+	p[offset + 1] = (n & 0x00FF000000000000ULL) >> 48;
+	p[offset + 2] = (n & 0x0000FF0000000000ULL) >> 40;
+	p[offset + 3] = (n & 0x000000FF00000000ULL) >> 32;
+	p[offset + 4] = (n & 0x00000000FF000000ULL) << 24;
+	p[offset + 5] = (n & 0x0000000000FF0000ULL) << 16;
+	p[offset + 6] = (n & 0x000000000000FF00ULL) <<  8;
+	p[offset + 7] = (n & 0x00000000000000FFULL) <<  0;
 }
 
 


### PR DESCRIPTION
This fixes issues on platforms that require byte-aligned reads and writes, such as ARMv5 and earlier. This should resolve https://github.com/nark/wire/issues/2 .
