### PR TITLE
Use mkstemp instead of mktemp

### DIFF
--- a/libwired/file/wi-fs.c
+++ b/libwired/file/wi-fs.c
@@ -102,7 +102,7 @@ wi_string_t * wi_fs_temporary_path_with_template(wi_string_t *template) {
 	
 	wi_strlcpy(path, wi_string_cstring(template), sizeof(path));
 	
-	if(!mktemp(path))
+	if(!mkstemp(path))
 		return NULL;
 	
 	return wi_string_with_cstring(path);


### PR DESCRIPTION
This avoids warnings like the following, and is ostensibly more secure.
libwired/file/wi-fs.c:105: warning: the use of `mktemp' is dangerous, better use `mkstemp'